### PR TITLE
Added More Methods to Load DataFrame

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package dataframe
 
 import (
+	"bytes"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -87,6 +88,20 @@ func CreateDataFrame(path, fileName string) DataFrame {
 	// Setup the reader
 	reader := csv.NewReader(recordFile)
 
+	return CreateDataFrameFromCsvReader(reader)
+}
+
+// Generate a new DataFrame sourced from an array of bytes containing csv data.
+func CreateDataFrameFromBytes(b []byte) DataFrame {
+	// Setup the reader
+	reader := csv.NewReader(bytes.NewReader(b))
+
+	return CreateDataFrameFromCsvReader(reader)
+
+}
+
+// Generate a new DataFrame sourced from a csv reader.
+func CreateDataFrameFromCsvReader(reader *csv.Reader) DataFrame {
 	// Read the records
 	header, err := reader.Read()
 	if err != nil {


### PR DESCRIPTION
This can be used when the files data is read from some remote storage service like GCS, AWS S3. Writing to a file and then reading it again will add on overhead.